### PR TITLE
EnergyMeleeWeaponsBuff

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
@@ -7,7 +7,8 @@
   - type: EnergySword
     litDamageBonus:
         types:
-            Heat: 17
+            Heat: 15
+            Slash: 15
             Blunt: -4.5
     litDisarmMalus: 0.6
   - type: Sprite
@@ -30,7 +31,7 @@
   - type: Item
     size: 5
     sprite: Objects/Weapons/Melee/e_sword.rsi
-  - type: UseDelay
+  - type: UseDelay  
     delay: 1.0
   - type: PointLight
     enabled: false
@@ -64,7 +65,8 @@
     secret: true
     litDamageBonus:
         types:
-            Heat: 13
+            Heat: 7
+            Slash: 7
             Blunt: -1
     litDisarmMalus: 0.4
   - type: Sprite


### PR DESCRIPTION
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR <!--Buffed Energy Sword and Energy Dagger due to them feeling extremely weak -->

**Media**
<!-- 
If applicable, add screenshots or videos to showcase your PR. Small fixes/refactors are exempt, but all PRs which make ingame changes 


Check one of the boxes below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [ ] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Energy Sword now deals 15 heat and 15 Slash when lit. Energy Dagger now deals 9 burn and 9 Slash when lit.
-->

:cl: Tryded
- add: Added fun!
- remove: Removed fun!

